### PR TITLE
Fixed logic to support SDK 34

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,14 +71,19 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="de.appplant.cordova.plugin.background.ForegroundService" />
+            <service
+              android:name="de.appplant.cordova.plugin.background.ForegroundService"
+              android:foregroundServiceType="dataSync"
+              android:exported="false">
+            </service>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.WAKE_LOCK" />
-			<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
             <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
             <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
         </config-file>
 
         <source-file

--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -23,8 +23,10 @@ package de.appplant.cordova.plugin.background;
 
 import android.app.Activity;
 import android.content.*;
+import android.content.Context;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.os.Build;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -83,7 +85,11 @@ public class BackgroundMode extends CordovaPlugin {
         super.initialize(cordova, webView);
         IntentFilter filter = new IntentFilter();
         filter.addAction("com.backgroundmode.close" + cordova.getContext().getPackageName());
-        cordova.getActivity().registerReceiver(receiver, filter);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+          cordova.getActivity().registerReceiver(receiver, filter);
+        } else {
+          cordova.getActivity().registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        }
 
     }
 

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -23,17 +23,24 @@ package de.appplant.cordova.plugin.background;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
-import android.app.*;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.content.res.Resources;
 import android.graphics.drawable.Icon;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
-import org.json.JSONObject;
+
 import androidx.core.app.NotificationCompat;
+
+import org.json.JSONObject;
 
 import static android.os.PowerManager.PARTIAL_WAKE_LOCK;
 
@@ -126,7 +133,11 @@ public class ForegroundService extends Service {
         boolean isSilent    = settings.optBoolean("silent", false);
 
         if (!isSilent) {
-            startForeground(NOTIFICATION_ID, makeNotification());
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+              startForeground(NOTIFICATION_ID, makeNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+          } else {
+              startForeground(NOTIFICATION_ID, makeNotification());
+          }
         }
 
         PowerManager pm = (PowerManager)getSystemService(POWER_SERVICE);


### PR DESCRIPTION
Integrated additional requirements on Foreground service.

Added RECEIVED_NOT_EXPORTED call to Background register (required in Android 34).